### PR TITLE
Better pipeline names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,7 @@ module "pttp-infrastructure-ci-pipeline" {
   github_repo_name         = "pttp-infrastructure"
   git_branch_name          = "master"
 
+  name        = "Staff Device Logging"
   prefix_name = module.label.id
   vpc_id      = module.vpc.vpc_id
   subnet_ids  = module.vpc.private_subnets
@@ -89,6 +90,7 @@ module "pttp-infrastructure-ci-pipeline-dns-dhcp" {
   github_repo_name         = "staff-device-dns-dhcp-infrastructure"
   git_branch_name          = "main"
 
+  name        = "${module.label.id}-dns-dhcp-core-pipeline"
   prefix_name = "${module.label.id}-dns-dhcp"
   vpc_id      = module.vpc.vpc_id
   subnet_ids  = module.vpc.private_subnets
@@ -105,6 +107,7 @@ module "pttp-infrastructure-ci-pipeline-dhcp-container" {
   github_repo_name         = "staff-device-dhcp-server"
   git_branch_name          = "main"
 
+  name        = "${module.label.id}-kea-server-core-pipeline"
   prefix_name = "${module.label.id}-kea-server"
   vpc_id      = module.vpc.vpc_id
   subnet_ids  = module.vpc.private_subnets
@@ -123,6 +126,7 @@ module "pttp-infrastructure-ci-pipeline-dns-dhcp-admin-container" {
   github_repo_name         = "staff-device-dns-dhcp-admin"
   git_branch_name          = "main"
 
+  name        = "${module.label.id}-admin-core-pipeline"
   prefix_name = "${module.label.id}-admin"
   vpc_id      = module.vpc.vpc_id
   subnet_ids  = module.vpc.private_subnets
@@ -141,6 +145,7 @@ module "pttp-infrastructure-ci-pipeline-dns-container" {
   github_repo_name         = "staff-device-dns-server"
   git_branch_name          = "main"
 
+  name        = "${module.label.id}-dns-server-core-pipeline"
   prefix_name = "${module.label.id}-dns-server"
   vpc_id      = module.vpc.vpc_id
   subnet_ids  = module.vpc.private_subnets
@@ -159,6 +164,7 @@ module "pttp-infrastructure-ci-pipeline-infra-monitoring-alerting" {
   github_repo_name         = "staff-infrastructure-monitoring"
   git_branch_name          = "main"
 
+  name        = "${module.label.id}-ima-core-pipeline"
   prefix_name = "${module.label.id}-ima"
   vpc_id      = module.vpc.vpc_id
   subnet_ids  = module.vpc.private_subnets
@@ -175,6 +181,7 @@ module "pttp-infrastructure-ci-pipeline-grafana-config" {
   github_repo_name         = "staff-infrastructure-monitoring-datasource-config"
   git_branch_name          = "main"
 
+  name        = "${module.label.id}-grafana-config--pipeline"
   prefix_name = "${module.label.id}-grafana-config"
   vpc_id      = module.vpc.vpc_id
   subnet_ids  = module.vpc.private_subnets
@@ -191,6 +198,7 @@ module "pttp-infrastructure-ci-pipeline-infra-monitoring-alerting-snmpexporter" 
   github_repo_name         = "staff-infrastructure-monitoring-snmpexporter"
   git_branch_name          = "main"
 
+  name        = "${module.label.id}-snmp-core-pipeline"
   prefix_name = "${module.label.id}-snmp"
   vpc_id      = module.vpc.vpc_id
   subnet_ids  = module.vpc.private_subnets
@@ -207,6 +215,7 @@ module "pttp-public-key-infrastructure-pipeline" {
   github_repo_name         = "staff-infrastructure-certificate-services"
   git_branch_name          = "main"
 
+  name        = "${module.label.id}-pki-core-pipeline"
   prefix_name = "${module.label.id}-pki"
   vpc_id      = module.vpc.vpc_id
   subnet_ids  = module.vpc.private_subnets

--- a/modules/ci-pipeline/main.tf
+++ b/modules/ci-pipeline/main.tf
@@ -140,7 +140,7 @@ data "aws_ssm_parameter" "github_oauth_token" {
 }
 
 resource "aws_codepipeline" "codepipeline" {
-  name     = "${var.prefix_name}-${var.service_name}-pipeline"
+  name     = var.name
   role_arn = aws_iam_role.codepipeline_role.arn
 
   artifact_store {

--- a/modules/ci-pipeline/variables.tf
+++ b/modules/ci-pipeline/variables.tf
@@ -47,3 +47,7 @@ variable "privileged_mode" {
   type    = bool
   default = false
 }
+
+variable "name" {
+  type = string
+}


### PR DESCRIPTION
This allows control over the pipeline names displayed in CodePipeline.
It will only rename the Logging pipeline but allows renaming the rest of
the pipelines if required.

Currently the pipeline names are heavily prefixed and makes it difficult
to scan, containing irrelevant name segments such as "core".