### PR TITLE
Move cross account log subscriptions out of main file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ An OAuth token is required to pull your source code from Github.
 
 Create an access token for your repository and add it to a `.tfvars` file in the root of the project.
 
+The local configuration file (terraform.tfvars) is required to exist locally before running this terraform.
+It is stored in SSM Parameter Store under the key `/staff-device/shared-services/terraform.tfvars`.
+
+Copy the contents into a local terraform.tfvars in the root of this project.
+
 ```shell script
 github_oauth_token = "abc123"
 ```

--- a/main.tf
+++ b/main.tf
@@ -269,32 +269,9 @@ module "staff-infrastructure-monitoring-blackbox-exporter" {
 }
 
 module "log-forward" {
-  source          = "./modules/log-forwarding"
-  destination_arn = var.kinesis_destination_arn
-  prefix_name     = module.label.id
-
-  subscription_log_group_names = [
-    "Panorama-Policy-as-Code-codepipeline-log-group",
-    "Panorama-codepipeline-log-group",
-    "pttp-ci-infrastructure-admin-log-group-core",
-    "pttp-ci-infrastructure-aggregation-log-group-",
-    "pttp-ci-infrastructure-bb-ex-log-group-core",
-    "pttp-ci-infrastructure-cloudtrail-log-group",
-    "pttp-ci-infrastructure-dns-dhcp-log-group-core",
-    "pttp-ci-infrastructure-dns-server-log-group-core",
-    "pttp-ci-infrastructure-ds-config-log-group-core",
-    "pttp-ci-infrastructure-grafana-config-log-group-",
-    "pttp-ci-infrastructure-ima-log-group-core",
-    "pttp-ci-infrastructure-kea-server-log-group-core",
-    "pttp-ci-infrastructure-log-group-core",
-    "pttp-ci-infrastructure-log-hc-log-group-core",
-    "pttp-ci-infrastructure-log-syslog-log-group-core",
-    "pttp-ci-infrastructure-pki-log-group-core",
-    "pttp-ci-infrastructure-snmp-log-group-core",
-    "pttp-ci-infrastructure-vpc-flow-logs-log-group",
-    "SOP-OCI-Access-codepipeline-log-group",
-    "TGW-codepipeline-log-group"
-  ]
+  source             = "./modules/log-forwarding"
+  prefix_name        = module.label.id
+  log_forward_config = var.log_forward_config
 }
 
 module "cloudtrail" {

--- a/modules/log-forwarding/main.tf
+++ b/modules/log-forwarding/main.tf
@@ -1,8 +1,26 @@
-resource "aws_cloudwatch_log_subscription_filter" "this" {
-  count = length(var.subscription_log_group_names)
+resource "aws_cloudwatch_log_subscription_filter" "production" {
+  count = length(var.log_forward_config.production.log_groups)
 
-  name            = element(var.subscription_log_group_names, count.index)
-  log_group_name  = element(var.subscription_log_group_names, count.index)
+  name            = element(var.log_forward_config.production.log_groups, count.index)
+  log_group_name  = element(var.log_forward_config.production.log_groups, count.index)
   filter_pattern  = ""
-  destination_arn = var.destination_arn
+  destination_arn = var.log_forward_config.production.destination_arn
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "pre_production" {
+  count = length(var.log_forward_config.pre_production.log_groups)
+
+  name            = element(var.log_forward_config.pre_production.log_groups, count.index)
+  log_group_name  = element(var.log_forward_config.pre_production.log_groups, count.index)
+  filter_pattern  = ""
+  destination_arn = var.log_forward_config.pre_production.destination_arn
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "development" {
+  count = length(var.log_forward_config.development.log_groups)
+
+  name            = element(var.log_forward_config.development.log_groups, count.index)
+  log_group_name  = element(var.log_forward_config.development.log_groups, count.index)
+  filter_pattern  = ""
+  destination_arn = var.log_forward_config.development.destination_arn
 }

--- a/modules/log-forwarding/variables.tf
+++ b/modules/log-forwarding/variables.tf
@@ -1,11 +1,20 @@
-variable "destination_arn" {
-  type = string
-}
-
 variable "prefix_name" {
   type = string
 }
 
-variable "subscription_log_group_names" {
-  type = list(string)
+variable "log_forward_config" {
+  type = object({
+    production = object({
+      destination_arn = string
+      log_groups = list(string)
+    }),
+    pre_production = object({
+      destination_arn = string
+      log_groups = list(string)
+    }),
+    development = object({
+      destination_arn = string
+      log_groups = list(string)
+    })
+  })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,10 +20,23 @@ variable "production_assume_role_arn" {
   type = string
 }
 
-variable "kinesis_destination_arn" {
-  type = string
-}
-
 variable "enable_cloudtrail_log_shipping_to_cloudwatch" {
   type = bool
+}
+
+variable "log_forward_config" {
+  type = object({
+    production = object({
+      destination_arn = string
+      log_groups = list(string)
+    }),
+    pre_production = object({
+      destination_arn = string
+      log_groups = list(string)
+    }),
+    development = object({
+      destination_arn = string
+      log_groups = list(string)
+    })
+  })
 }


### PR DESCRIPTION
These are now set in terraform.tfvars file locally.
An example of this has been uploaded to SSM Parameter store in Shared
services. It can be found under `/staff-device/shared-services/terraform.tfvars`

Ensure logs are sent from shared services to all 3 accounts so they are
identical and alarms can be configured in the same way.