### PR TITLE
Add ECR repositories for the base images used by the IMA Platform

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -337,5 +337,5 @@ module "logging_heartbeat" {
 module "ecr_images" {
   source = "./modules/ecr_images"
 
-  repositories = ["admin", "admin-mysql", "dhcp", "dhcp-mysql", "dns", "nginx"]
+  repositories = ["admin", "admin-mysql", "dhcp", "dhcp-mysql", "dns", "nginx", "prometheus", "snmp-exporter", "blackbox-exporter"]
 }


### PR DESCRIPTION
ECR repositories are required for IMA's following repositories to mitigate against Docker Hub rate limits:

- https://github.com/ministryofjustice/staff-infrastructure-metric-aggregation-server/blob/main/Dockerfile
- https://github.com/ministryofjustice/staff-infrastructure-monitoring-snmpexporter/blob/main/Dockerfile
- https://github.com/ministryofjustice/staff-infrastructure-monitoring-blackbox-exporter/blob/main/Dockerfile